### PR TITLE
fix: empty claims resulted in unability to share userId

### DIFF
--- a/src/pages/Connect/Flow/DataRequests/index.tsx
+++ b/src/pages/Connect/Flow/DataRequests/index.tsx
@@ -195,8 +195,10 @@ export default function DataRequests({
   /* ************************************************************* */
 
   useEffect(() => {
-    const claims = sismoConnectRequest.claims;
-    const auths = sismoConnectRequest.auths;
+    const claims =
+      sismoConnectRequest.claims.length > 0 ? sismoConnectRequest.claims : null;
+    const auths =
+      sismoConnectRequest.auths.length > 0 ? sismoConnectRequest.auths : null;
 
     if (!claims && !auths) {
       setLoadingEligible(false);


### PR DESCRIPTION
Empty claims were preventing users from sharing their userId, it can be an issue when devs comment out their claims quickly in their React Button for example.
While the best way to fix it is by checking it in the client package, it can be a good quick fix for now.

This behavior in the Sismo Connect App should not break anything in the vault app:
```typescript
<SismoConnectButton
...
 
auths={[{ authType: AuthType.VAULT }]}
claims={[]}
/>
```